### PR TITLE
Fix stack buffer overflow in threaded RNS operations

### DIFF
--- a/src/core/rns_matrix.c
+++ b/src/core/rns_matrix.c
@@ -257,11 +257,11 @@ static void * residue_gemm_thread(void * arg)
 
 void rnsMatrix_gemm(rnsMatrix_t * dst, rnsMatrix_t const * A, rnsMatrix_t const * B)
 {
-  gemm_args_t args[32];
-  pthread_t thread[32];
-
   long j;
   long nmod = dst->nmod;
+  gemm_args_t * args = malloc(nmod * sizeof(gemm_args_t));
+  pthread_t * thread = malloc(nmod * sizeof(pthread_t));
+
   for (j = 0; j < nmod; ++j) {
     args[j].dst = dst->residues[j];
     args[j].A = A->residues[j];
@@ -272,6 +272,8 @@ void rnsMatrix_gemm(rnsMatrix_t * dst, rnsMatrix_t const * A, rnsMatrix_t const 
   for (j = 0; j < nmod; ++j) {
     pthread_join(thread[j], NULL);
   }
+  free(args);
+  free(thread);
 }
 
 struct quadLift_args {
@@ -294,11 +296,10 @@ void rnsMatrix_quadLift(rnsMatrix_t * dst, rnsMatrix_t const * T,
                         rnsMatrix_t const * A, rnsMatrix_t const * M,
                         long const * Xinv)
 {
-  quadLift_args_t args[32];
-  pthread_t thread[32];
-
   long j;
   long nmod = dst->nmod;
+  quadLift_args_t * args = malloc(nmod * sizeof(quadLift_args_t));
+  pthread_t * thread = malloc(nmod * sizeof(pthread_t));
   for (j = 0; j < nmod; ++j) {
     args[j].dst = dst->residues[j];
     args[j].T = T->residues[j];
@@ -311,6 +312,8 @@ void rnsMatrix_quadLift(rnsMatrix_t * dst, rnsMatrix_t const * T,
   for (j = 0; j < nmod; ++j) {
     pthread_join(thread[j], NULL);
   }
+  free(args);
+  free(thread);
 }
 #endif
 

--- a/src/lift/rns_conversion.c
+++ b/src/lift/rns_conversion.c
@@ -126,22 +126,25 @@ static void * rnsMatrix_convertOne_thread(void * arg)
 
 void rnsMatrix_convert(rnsMatrix_t * Aq, rnsMatrix_t const * Ap)
 {
-  conv_args_t args[32];
-  pthread_t thread[32];
   long j;
+  long nmod = Aq->nmod;
+  conv_args_t * args = malloc(nmod * sizeof(conv_args_t));
+  pthread_t * thread = malloc(nmod * sizeof(pthread_t));
 
   residue_t * r = correctionFactor(Ap);
 
-  for (j = 0; j < Aq->nmod; ++j) {
+  for (j = 0; j < nmod; ++j) {
     args[j].Aq_i = Aq->residues[j];
     args[j].Ap = Ap;
     args[j].r = r;
 
     pthread_create(&thread[j], NULL, rnsMatrix_convertOne_thread, &(args[j]));
   }
-  for (j = 0; j < Aq->nmod; ++j) {
+  for (j = 0; j < nmod; ++j) {
     pthread_join(thread[j], NULL);
   }
+  free(args);
+  free(thread);
 }
 
 #endif


### PR DESCRIPTION
## Summary

The thread and argument arrays in `rnsMatrix_gemm`, `rnsMatrix_quadLift` (`src/core/rns_matrix.c`), and `rnsMatrix_convert` (`src/lift/rns_conversion.c`) are declared as fixed-size `[32]` on the stack. If the RNS basis has more than 32 moduli (which occurs for large matrices with large entries), this overflows and causes memory corruption or crashes.

Changed to dynamic allocation via `malloc`, sized to the actual number of moduli.

## Test plan

- [x] Builds and passes for primes 3 through 1009 on macOS ARM64 (FLINT 3, GMP 6, OpenBLAS)